### PR TITLE
Add transaction support

### DIFF
--- a/solidity-bindgen-macros/src/abi_gen.rs
+++ b/solidity-bindgen-macros/src/abi_gen.rs
@@ -1,4 +1,4 @@
-use crate::abi_json::{abi_from_json, Abi};
+use crate::abi_json::{abi_from_json, Abi, StateMutability};
 use ethabi::param_type::{ParamType, Reader};
 use inflector::cases::snakecase::to_snake_case;
 use proc_macro2::{Ident, Span, TokenStream};
@@ -124,8 +124,10 @@ pub fn fn_from_abi(abi: &Abi, span: Span) -> TokenStream {
                 quote! { (#(#params),*) }
             };
 
-            let transaction = function.constant.unwrap_or_default();
-
+            let transaction = matches!(
+                function.state_mutability,
+                StateMutability::Nonpayable | StateMutability::Payable
+            );
             let method = if transaction { "send" } else { "call" };
             let method = Ident::new(method, Span::call_site());
 

--- a/solidity-bindgen-macros/src/abi_gen.rs
+++ b/solidity-bindgen-macros/src/abi_gen.rs
@@ -14,26 +14,27 @@ pub fn abi_from_file(path: impl AsRef<Path>, span: Span) -> TokenStream {
         .to_owned();
     let bytes = std::fs::read(path).unwrap();
     let fn_abis = abi_from_json(&bytes);
-    let abi_str = String::from_utf8(bytes).unwrap();
+
+    // See also 4cd1038f-56f2-4cf2-8dbe-672da9006083
+    let _validated_abis = ethabi::Contract::load(&bytes[..]).expect("Could not validate ABIs");
+    let abi_str = String::from_utf8(bytes).expect("Abis need to be valid UTF-8");
 
     let struct_name = Ident::new(name.as_str(), span);
 
     let fns = fn_abis.iter().map(|abi| fn_from_abi(abi, span));
 
     quote! {
-        #[allow(dead_code)]
         pub struct #struct_name {
             contract: ::solidity_bindgen::internal::ContractWrapper,
         }
 
-        #[allow(dead_code, unused_parens)]
         impl #struct_name {
-            pub fn new(address: ::web3::types::Address, url: &str, event_loop_handle: ::std::sync::Arc<::web3::transports::EventLoopHandle>) -> ::solidity_bindgen::internal::Result<Self> {
+            pub fn new(address: ::web3::types::Address, context: &::solidity_bindgen::Context) -> ::std::result::Result<Self, ::web3::Error> {
                 // Embed ABI into the program
                 let abi = #abi_str;
 
                 // Set up a wrapper so we can make calls
-                let contract = ::solidity_bindgen::internal::ContractWrapper::new(address, abi.as_bytes(), url, event_loop_handle)?;
+                let contract = ::solidity_bindgen::internal::ContractWrapper::new(address, context, abi.as_bytes())?;
                 Ok(Self {
                     contract
                 })
@@ -105,7 +106,7 @@ pub fn fn_from_abi(abi: &Abi, span: Span) -> TokenStream {
             let rust_name = Ident::new(&to_rust_name("function", eth_name, 0), span);
 
             // Get the types and names of parameters
-            let params = function.inputs.iter().enumerate().map(|(i, param)| {
+            let params_in = function.inputs.iter().enumerate().map(|(i, param)| {
                 let name = Ident::new(&to_rust_name("input", &param.name, i), span);
                 let t = param_type(&param.r#type);
                 quote! {
@@ -113,43 +114,52 @@ pub fn fn_from_abi(abi: &Abi, span: Span) -> TokenStream {
                 }
             });
 
-            let body = {
-                let params = function.inputs.iter().enumerate().map(|(i, param)| {
-                    let name = Ident::new(&to_rust_name("input", &param.name, i), span);
-                    quote! { #name }
-                });
-                if function.constant.unwrap_or_default() {
-                    quote! {
-                        self.contract.query(#eth_name, (#(#params),*)).await
-                    }
-                } else {
-                    // Non-pure functions need to use call_with_verifications instead of query,
-                    // and payable functions may yet need something else
-                    quote! {
-                        self.contract.non_pure_todo(#eth_name, (#(#params),*)).await
-                    }
-                }
+            let params = function.inputs.iter().enumerate().map(|(i, param)| {
+                let name = Ident::new(&to_rust_name("input", &param.name, i), span);
+                quote! { #name }
+            });
+            let params = if function.inputs.len() == 1 {
+                quote! { #(#params)* }
+            } else {
+                quote! { (#(#params),*) }
             };
 
-            let ok = match function.outputs.len() {
-                0 => quote! { ::solidity_bindgen::internal::Empty },
-                1 => {
-                    let t = param_type(&function.outputs[0].r#type);
-                    quote! { #t }
-                }
-                _ => {
-                    let types = function.outputs.iter().map(|o| {
-                        let t = param_type(&o.r#type);
-                        quote! { #t }
-                    });
+            let transaction = function.constant.unwrap_or_default();
 
-                    quote! { (#(#types),*) }
+            let method = if transaction { "send" } else { "call" };
+            let method = Ident::new(method, Span::call_site());
+
+            let ok = if transaction {
+                // Despite information in the ABIs to the contrary, there aren't
+                // really outputs for web3 send fns. The outputs that are
+                // available aren't returned by these APIs, but are only made
+                // available to contracts calling each other. 🤷
+                //
+                // All you can get is a receipt. So, the way to get something
+                // like a return value would be to check for events emitted or
+                // to make further queries for data.
+                quote! { ::web3::types::TransactionReceipt }
+            } else {
+                match function.outputs.len() {
+                    0 => quote! { ::solidity_bindgen::internal::Empty },
+                    1 => {
+                        let t = param_type(&function.outputs[0].r#type);
+                        quote! { #t }
+                    }
+                    _ => {
+                        let types = function.outputs.iter().map(|o| {
+                            let t = param_type(&o.r#type);
+                            quote! { #t }
+                        });
+
+                        quote! { (#(#types),*) }
+                    }
                 }
             };
 
             quote! {
-                pub async fn #rust_name(&self, #(#params),*) -> ::solidity_bindgen::internal::Result<#ok> {
-                    #body
+                pub async fn #rust_name(&self, #(#params_in),*) -> ::std::result::Result<#ok, ::web3::Error> {
+                    self.contract.#method(#eth_name, #params).await
                 }
             }
         }

--- a/solidity-bindgen-macros/src/abi_json.rs
+++ b/solidity-bindgen-macros/src/abi_json.rs
@@ -23,8 +23,6 @@ pub struct Function {
     pub inputs: Vec<Param>,
     pub outputs: Vec<Param>,
     pub state_mutability: StateMutability,
-    // TODO: type can be omitted, defaulting to "function", likewise payable and constant can be omitted, both defaulting to false.
-    pub constant: Option<bool>,
 }
 
 #[derive(Deserialize, Debug)]

--- a/solidity-bindgen/Cargo.toml
+++ b/solidity-bindgen/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 
 [dependencies]
 solidity-bindgen-macros = { path = "../solidity-bindgen-macros" }
-web3 = "0.10.0"
-anyhow = "1.0.28"
+web3 = "0.11.0"
 futures = { version="0.3.4", features=["compat"] }
-ethabi = "9.0"
+ethabi = "12.0.0"

--- a/solidity-bindgen/src/context.rs
+++ b/solidity-bindgen/src/context.rs
@@ -1,0 +1,36 @@
+use std::sync::Arc;
+use web3::transports::EventLoopHandle;
+use web3::types::Address;
+
+/// A type needed to instantiate contracts. All contracts instantiated with the
+/// same Context will share the same EventLoopHandle. As long as the contracts
+/// are not dropped, the EventLoopHandle will not be dropped either. This type
+/// is cheap to clone.
+#[derive(Clone)]
+pub struct Context(Arc<ContextInner>);
+
+struct ContextInner {
+    url: String,
+    handle: EventLoopHandle,
+    from: Address,
+}
+
+impl Context {
+    pub fn new(url: String, from: Address) -> Result<Self, web3::error::Error> {
+        let handle = EventLoopHandle::spawn(|_| Ok(()))?.0;
+        let inner = ContextInner { url, handle, from };
+        Ok(Self(Arc::new(inner)))
+    }
+
+    pub fn url(&self) -> &str {
+        &self.0.url
+    }
+
+    pub fn from(&self) -> Address {
+        self.0.from
+    }
+
+    pub(crate) fn handle(&self) -> &EventLoopHandle {
+        &self.0.handle
+    }
+}

--- a/solidity-bindgen/src/lib.rs
+++ b/solidity-bindgen/src/lib.rs
@@ -2,5 +2,9 @@
 #[doc(hidden)]
 pub mod internal;
 
+mod context;
+
 // Re-export the macros
 pub use solidity_bindgen_macros::*;
+
+pub use context::Context;


### PR DESCRIPTION
Adds transaction support to generated contracts. A few more niceties:

Contract ABIs are validated at compile time.
Generated code does not require suppressing warnings for unused parens.
EventLoopHandle management moves into this library in the new `Context` struct
Mapping query errors to `web3::Error` instead of `web3::contract::Error` means that we don't need `anyhow` because errors become convenient to work with again (they implement `Send` and are consistently typed between `new`, `send`, and `call` so `?` can be used)
Terminology changed to match the js `web3` instead of the unnecessarily renamed terminology of Parity.