### PR TITLE
Added transaction signing

### DIFF
--- a/solidity-bindgen/Cargo.toml
+++ b/solidity-bindgen/Cargo.toml
@@ -7,6 +7,10 @@ edition = "2018"
 
 [dependencies]
 solidity-bindgen-macros = { path = "../solidity-bindgen-macros" }
-web3 = "0.11.0"
-futures = { version="0.3.4", features=["compat"] }
+# Can go back to the crates.io version once this is merged and published:
+# https://github.com/tomusdrw/rust-web3/pull/352
+web3 = { git = "https://github.com/That3Percent/rust-web3", branch = "custom-signing-methods" }
+futures = { version="0.3.5", features=["compat"] }
 ethabi = "12.0.0"
+secp256k1 = "0.17.2"
+zeroize = "1.1.0"

--- a/solidity-bindgen/Cargo.toml
+++ b/solidity-bindgen/Cargo.toml
@@ -14,3 +14,4 @@ futures = { version="0.3.5", features=["compat"] }
 ethabi = "12.0.0"
 secp256k1 = "0.17.2"
 zeroize = "1.1.0"
+sodiumoxide = "0.2.5"

--- a/solidity-bindgen/src/context.rs
+++ b/solidity-bindgen/src/context.rs
@@ -1,3 +1,5 @@
+use crate::SafeSecretKey;
+use secp256k1::key::SecretKey;
 use std::sync::Arc;
 use web3::transports::EventLoopHandle;
 use web3::types::Address;
@@ -13,12 +15,22 @@ struct ContextInner {
     url: String,
     handle: EventLoopHandle,
     from: Address,
+    secret_key: SafeSecretKey,
 }
 
 impl Context {
-    pub fn new(url: String, from: Address) -> Result<Self, web3::error::Error> {
+    pub fn new(
+        url: String,
+        from: Address,
+        secret_key: &SecretKey,
+    ) -> Result<Self, web3::error::Error> {
         let handle = EventLoopHandle::spawn(|_| Ok(()))?.0;
-        let inner = ContextInner { url, handle, from };
+        let inner = ContextInner {
+            url,
+            handle,
+            from,
+            secret_key: secret_key.into(),
+        };
         Ok(Self(Arc::new(inner)))
     }
 
@@ -32,5 +44,9 @@ impl Context {
 
     pub(crate) fn handle(&self) -> &EventLoopHandle {
         &self.0.handle
+    }
+
+    pub(crate) fn secret_key(&self) -> &SecretKey {
+        &self.0.secret_key
     }
 }

--- a/solidity-bindgen/src/context.rs
+++ b/solidity-bindgen/src/context.rs
@@ -1,5 +1,6 @@
 use crate::SafeSecretKey;
 use secp256k1::key::SecretKey;
+use std::convert::TryInto as _;
 use std::sync::Arc;
 use web3::transports::EventLoopHandle;
 use web3::types::Address;
@@ -29,7 +30,7 @@ impl Context {
             url,
             handle,
             from,
-            secret_key: secret_key.into(),
+            secret_key: secret_key.try_into().unwrap(),
         };
         Ok(Self(Arc::new(inner)))
     }

--- a/solidity-bindgen/src/internal/types.rs
+++ b/solidity-bindgen/src/internal/types.rs
@@ -1,0 +1,33 @@
+use ethabi::Token;
+use web3::contract::tokens::{Detokenize, Tokenizable};
+use web3::contract::Error;
+
+/// For types which might come up in contracts which are not yet implemented in web3
+pub enum Unimplemented {}
+impl Tokenizable for Unimplemented {
+    fn from_token(_: Token) -> Result<Self, Error>
+    where
+        Self: Sized,
+    {
+        unimplemented!()
+    }
+    #[inline(always)]
+    fn into_token(self) -> Token {
+        unsafe { std::hint::unreachable_unchecked() }
+    }
+}
+
+/// This type compensates for the fact that web3 doesn't impl Detokenize for ()
+pub struct Empty;
+impl Detokenize for Empty {
+    fn from_tokens(tokens: Vec<Token>) -> std::result::Result<Self, Error>
+    where
+        Self: Sized,
+    {
+        if tokens.is_empty() {
+            Ok(Empty)
+        } else {
+            Err(Error::InvalidOutputType("Expected no tokens".to_owned()))
+        }
+    }
+}

--- a/solidity-bindgen/src/lib.rs
+++ b/solidity-bindgen/src/lib.rs
@@ -1,8 +1,11 @@
-// A module for implementation that needs to be exposed to macros
+/// A module for implementation that needs to be exposed to macros
 #[doc(hidden)]
 pub mod internal;
 
 mod context;
+mod secrets;
+
+pub use secrets::SafeSecretKey;
 
 // Re-export the macros
 pub use solidity_bindgen_macros::*;

--- a/solidity-bindgen/src/secrets.rs
+++ b/solidity-bindgen/src/secrets.rs
@@ -1,0 +1,80 @@
+use secp256k1::key::{SecretKey, ONE_KEY};
+
+use std::fmt;
+use std::ops::Deref;
+use std::pin::Pin;
+use zeroize::{DefaultIsZeroes, Zeroize};
+
+/// Securely stores a secret key in memory that is zeroized on drop. Care is
+/// taken so that when this struct is constructed or moved that additional
+/// copies of the secret are not made in memory.
+/// https://github.com/veorq/cryptocoding#clean-memory-of-secret-data
+///
+/// Unfortunately the SafeSecretKey is not magic, there are some things to be
+/// aware of when using it...
+///   * The memory used when constructing the secret key must also be zeroized,
+///     but this is left as an exercise to the caller.
+///   * If you mem::forget the SafeSecretKey or otherwise don't drop it, the
+///     secret will not be zeroized.
+///   * When the caller lends out a reference to the SecretKey (available for
+///     example via Deref) it is the responsibility of the caller to not Clone
+///     the SecretKey or otherwise make a copy of it's memory
+pub struct SafeSecretKey {
+    safe: Pin<Box<ZeroizedSecretKey>>,
+}
+
+impl Clone for SafeSecretKey {
+    fn clone(&self) -> Self {
+        Self::new(&self)
+    }
+}
+
+impl fmt::Debug for SafeSecretKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SecretKey").finish()
+    }
+}
+
+#[derive(Copy, Clone)]
+struct ZeroizedSecretKey(SecretKey);
+
+impl DefaultIsZeroes for ZeroizedSecretKey {}
+impl Default for ZeroizedSecretKey {
+    fn default() -> Self {
+        Self(ONE_KEY)
+    }
+}
+
+impl SafeSecretKey {
+    fn new(secret: &SecretKey) -> Self {
+        // Allocate to a fixed location in memory
+        let mut safe = Pin::new(Box::<ZeroizedSecretKey>::default());
+
+        // Copy to that location without moving secret onto the stack
+        safe.0 = *secret;
+
+        // Now the only copy of the memory managed by Self is committed to be zeroized later.
+        // This operation (and subsequent) don't make copies because it's the Pin that moves,
+        // not the underlying allocation.
+        Self { safe }
+    }
+}
+
+impl<'a> From<&'a SecretKey> for SafeSecretKey {
+    fn from(secret: &'a SecretKey) -> Self {
+        Self::new(secret)
+    }
+}
+
+impl Drop for SafeSecretKey {
+    fn drop(&mut self) {
+        self.safe.zeroize()
+    }
+}
+
+impl Deref for SafeSecretKey {
+    type Target = SecretKey;
+    fn deref(&self) -> &Self::Target {
+        &self.safe.0
+    }
+}

--- a/solidity-bindgen/src/secrets.rs
+++ b/solidity-bindgen/src/secrets.rs
@@ -1,13 +1,16 @@
 use secp256k1::key::{SecretKey, ONE_KEY};
 
+use sodiumoxide::utils::{mlock, munlock};
+use std::convert::TryFrom;
 use std::fmt;
 use std::ops::Deref;
 use std::pin::Pin;
+use std::slice;
 use zeroize::{DefaultIsZeroes, Zeroize};
 
 /// Securely stores a secret key in memory that is zeroized on drop. Care is
 /// taken so that when this struct is constructed or moved that additional
-/// copies of the secret are not made in memory.
+/// copies of the secret are not made in memory or disk.
 /// https://github.com/veorq/cryptocoding#clean-memory-of-secret-data
 ///
 /// Unfortunately the SafeSecretKey is not magic, there are some things to be
@@ -21,12 +24,6 @@ use zeroize::{DefaultIsZeroes, Zeroize};
 ///     the SecretKey or otherwise make a copy of it's memory
 pub struct SafeSecretKey {
     safe: Pin<Box<ZeroizedSecretKey>>,
-}
-
-impl Clone for SafeSecretKey {
-    fn clone(&self) -> Self {
-        Self::new(&self)
-    }
 }
 
 impl fmt::Debug for SafeSecretKey {
@@ -45,10 +42,23 @@ impl Default for ZeroizedSecretKey {
     }
 }
 
+impl ZeroizedSecretKey {
+    fn as_mut_bytes(&mut self) -> &mut [u8] {
+        unsafe {
+            let ptr = self.0.as_mut_ptr();
+            slice::from_raw_parts_mut(ptr, self.0.len())
+        }
+    }
+}
+
 impl SafeSecretKey {
-    fn new(secret: &SecretKey) -> Self {
+    fn new(secret: &SecretKey) -> Result<Self, ()> {
         // Allocate to a fixed location in memory
         let mut safe = Pin::new(Box::<ZeroizedSecretKey>::default());
+
+        // Tell the OS that it's not ok to page this memory to disk
+        let mem = safe.as_mut_bytes();
+        mlock(mem)?;
 
         // Copy to that location without moving secret onto the stack
         safe.0 = *secret;
@@ -56,19 +66,24 @@ impl SafeSecretKey {
         // Now the only copy of the memory managed by Self is committed to be zeroized later.
         // This operation (and subsequent) don't make copies because it's the Pin that moves,
         // not the underlying allocation.
-        Self { safe }
+        Ok(Self { safe })
     }
 }
 
-impl<'a> From<&'a SecretKey> for SafeSecretKey {
-    fn from(secret: &'a SecretKey) -> Self {
+impl<'a> TryFrom<&'a SecretKey> for SafeSecretKey {
+    type Error = ();
+    fn try_from(secret: &'a SecretKey) -> Result<Self, ()> {
         Self::new(secret)
     }
 }
 
 impl Drop for SafeSecretKey {
     fn drop(&mut self) {
-        self.safe.zeroize()
+        self.safe.zeroize();
+        let mem = self.safe.as_mut_bytes();
+        // If the OS cannot unlock this memory, it's not a problem. There is no
+        // reasonable way to propagate an error so just ignore it.
+        let _ignore = munlock(mem);
     }
 }
 
@@ -76,5 +91,20 @@ impl Deref for SafeSecretKey {
     type Target = SecretKey;
     fn deref(&self) -> &Self::Target {
         &self.safe.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use secp256k1::key::ONE_KEY;
+
+    /// It's a bit hard to verify the inner workings like zeroing without relying on undefined behavior.
+    /// But, we can check that this at least runs
+    #[test]
+    pub fn no_panic() {
+        let key = ONE_KEY;
+        let safe = SafeSecretKey::new(&key).unwrap();
+        drop(safe);
     }
 }


### PR DESCRIPTION
Summary of changes:

Everything in internal/types.rs was moved out of internal/mod.rs, the only thing added was a comment (not much review required, but git doesn't know that)

Added `signed_call_with_confirmations` to `rust-web3` here: [https://github.com/tomusdrw/rust-web3/pull/352](https://github.com/tomusdrw/rust-web3/pull/352)

Use `signed_call_with_confirmations` within the contract

Added `SafeSecretKey` to securely manage private memory in as close to a foolproof way as possible. Might separate this into a separate crate.
