### PR TITLE
Updated to web3 0.13.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,4 @@ members = [
 [patch.crates-io]
 ethabi = { git = "https://github.com/graphprotocol/ethabi" }
 #ethabi = { path = "../ethabi/ethabi" }
-web3 = { git = "https://github.com/That3Percent/rust-web3", branch = "custom-signing-methods" }
+web3 = { git = "https://github.com/tomusdrw/rust-web3" }

--- a/solidity-bindgen/Cargo.toml
+++ b/solidity-bindgen/Cargo.toml
@@ -7,10 +7,8 @@ edition = "2018"
 
 [dependencies]
 solidity-bindgen-macros = { path = "../solidity-bindgen-macros" }
-# Can go back to the crates.io version once this is merged and published:
-# https://github.com/tomusdrw/rust-web3/pull/352
-web3 = { git = "https://github.com/That3Percent/rust-web3", branch = "custom-signing-methods" }
-futures = { version="0.3.5", features=["compat"] }
+web3 = "0.13.0"
+futures = "0.3.5"
 ethabi = "12.0.0"
 secp256k1 = "0.17.2"
 zeroize = "1.1.0"


### PR DESCRIPTION
Which nicely removed some weirdness about `EventLoopHandle` (which no longer exists) and removed the futures compat layer.