### PR TITLE
Expose a send function that overrides default gas options and confirmation blocks

### DIFF
--- a/solidity-bindgen-macros/src/abi_gen.rs
+++ b/solidity-bindgen-macros/src/abi_gen.rs
@@ -57,14 +57,14 @@ pub fn abi_from_file(path: impl AsRef<Path>) -> TokenStream {
                 })
             }
 
-            pub async fn send_with_confirmations(
+            pub async fn send(
                 &self,
                 func: &'static str,
                 params: impl web3::contract::tokens::Tokenize,
-                options: ::web3::contract::Options,
-                confirmations: usize,
+                options: Option<::web3::contract::Options>,
+                confirmations: Option<usize>,
             ) -> Result<::web3::types::TransactionReceipt, ::web3::Error> {
-                self.contract.send_with_confirmations(func, params, options, confirmations).await
+                self.contract.send(func, params, options, confirmations).await
             }
 
             #(#fns)*
@@ -211,9 +211,15 @@ pub fn fn_from_abi(function: &Function) -> TokenStream {
         }
     };
 
+    let fn_call = if method == "send" {
+        quote! { self.contract.#method(#eth_name, #params, None, None).await }
+    } else {
+        quote! { self.contract.#method(#eth_name, #params).await }
+    };
+
     quote! {
         pub async fn #rust_name(&self, #(#params_in),*) -> ::std::result::Result<#ok, ::web3::Error> {
-            self.contract.#method(#eth_name, #params).await
+            #fn_call
         }
     }
 }

--- a/solidity-bindgen-macros/src/abi_gen.rs
+++ b/solidity-bindgen-macros/src/abi_gen.rs
@@ -57,6 +57,16 @@ pub fn abi_from_file(path: impl AsRef<Path>) -> TokenStream {
                 })
             }
 
+            pub async fn send_with_confirmations(
+                &self,
+                func: &'static str,
+                params: impl web3::contract::tokens::Tokenize,
+                options: ::web3::contract::Options,
+                confirmations: usize,
+            ) -> Result<::web3::types::TransactionReceipt, ::web3::Error> {
+                self.contract.send_with_confirmations(func, params, options, confirmations).await
+            }
+
             #(#fns)*
         }
     }

--- a/solidity-bindgen/src/internal/mod.rs
+++ b/solidity-bindgen/src/internal/mod.rs
@@ -55,44 +55,28 @@ impl ContractWrapper {
         &self,
         func: &'static str,
         params: impl Tokenize,
-    ) -> Result<TransactionReceipt, web3::Error> {
-        self.send_with_options(func, params, Default::default())
-            .await
-    }
-
-    pub async fn send_with_options(
-        &self,
-        func: &'static str,
-        params: impl Tokenize,
-        options: Options,
-    ) -> Result<TransactionReceipt, web3::Error> {
-        self.send_with_confirmations(
-            func, params, options,
-            // Num confirmations. From a library standpoint, this should be
-            // a parameter of the function. Choosing a correct value is very
-            // difficult, even for a consumer of the library as it would
-            // require assessing the value of the transaction, security
-            // margins, and a number of other factors for which data may not
-            // be available. So just picking a pretty high security margin
-            // for now.
-            24,
-        )
-        .await
-    }
-
-    pub async fn send_with_confirmations(
-        &self,
-        func: &'static str,
-        params: impl Tokenize,
-        options: Options,
-        confirmations: usize,
+        options: Option<Options>,
+        confirmations: Option<usize>,
     ) -> Result<TransactionReceipt, web3::Error> {
         self.contract
             .signed_call_with_confirmations(
                 func,
                 params,
-                options,
-                confirmations,
+                match options {
+                    None => Default::default(),
+                    Some(options) => options,
+                },
+                match confirmations {
+                    // Num confirmations. From a library standpoint, this should be
+                    // a parameter of the function. Choosing a correct value is very
+                    // difficult, even for a consumer of the library as it would
+                    // require assessing the value of the transaction, security
+                    // margins, and a number of other factors for which data may not
+                    // be available. So just picking a pretty high security margin
+                    // for now.
+                    None => 24,
+                    Some(confirmations) => confirmations,
+                },
                 self.context.secret_key(),
             )
             .await


### PR DESCRIPTION
- Add optional arguments to the `send` function of the ContractsWrapper.
- Expose the function on contracts generation from ABI.